### PR TITLE
Add the snmp tool to the sonic-mgmt docker

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -23,6 +23,7 @@ RUN apt-get install -y \
                 curl \
                 cmake \
                 tcpdump \
+                snmp \
                 python-dev \
                 python-scapy
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
The snmp tool is required for interacting with certain type of PDU hosts in platform PSU/power related testing. This change is to have the snmp tool pre-built in the sonic-mgmt
docker image.

**- How I did it**
Updated the Dockerfile.j2 of docker-sonic-mgmt. Added "snmp" package to the "apt-get install" command.

**- How to verify it**
1. Build sonic-mgmt docker image. 
2. Start a docker container from the image.
3. Run command "snmpget" or "snmpwalk" to verify that the snmp tool is installed.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
